### PR TITLE
Add -V/--validate command line switch

### DIFF
--- a/src/BINK1998.cpp
+++ b/src/BINK1998.cpp
@@ -94,6 +94,15 @@ bool BINK1998::Verify(
     // Extract RPK, hash and signature from bytecode.
     Unpack(pRaw, pUpgrade, pSerial, pHash, pSignature);
 
+    if (options.verbose) {
+        fmt::print("Validation results:\n");
+        fmt::print("   Upgrade: 0x{:08x}\n", pUpgrade);
+        fmt::print("    Serial: 0x{:08x}\n", pSerial);
+        fmt::print("      Hash: 0x{:08x}\n", pHash);
+        fmt::print(" Signature: 0x{:08x}\n", pSignature);
+        fmt::print("\n");
+    }
+
     pData = pSerial << 1 | pUpgrade;
 
     /*

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -231,7 +231,7 @@ void CLI::printID(DWORD *pid)
 }
 
 void CLI::printKey(char *pk) {
-    assert(strlen(pk) >= 25);
+    assert(strlen(pk) >= PK_LENGTH);
 
     std::string spk = pk;
     fmt::print("{}-{}-{}-{}-{}\n",
@@ -242,7 +242,7 @@ void CLI::printKey(char *pk) {
                spk.substr(20,5));
 }
 
-int CLI::stripKey(const char *in_key, char *out_key) {
+bool CLI::stripKey(const char *in_key, char out_key[PK_LENGTH]) {
     // copy out the product key stripping out extraneous characters
     const char *p = in_key;
     size_t i = 0;
@@ -250,18 +250,19 @@ int CLI::stripKey(const char *in_key, char *out_key) {
         // strip out space or dash
 		if (*p == ' ' || *p == '-')
 			continue;
-        // check if we've passed 25 to avoid overflow
-        if (i >= 25)
-            return ++i;
-        // if character allowed, copy into array
-        for (int j = 0; j < 24; j++) {
+        // check if we've passed the product key length to avoid overflow
+        if (i >= PK_LENGTH)
+            return false;
+        // convert to uppercase - if character allowed, copy into array
+        for (int j = 0; j < strlen(pKeyCharset); j++) {
             if (toupper(*p) == pKeyCharset[j]) {
                 out_key[i++] = toupper(*p);
                 continue;
             }
         }
     }
-    return i;
+    // only return true if we've handled exactly PK_LENGTH chars
+    return (i == PK_LENGTH);
 }
 
 CLI::CLI(Options options, json keys) {
@@ -381,8 +382,8 @@ int CLI::BINK2002Generate() {
 int CLI::BINK1998Validate() {
     char product_key[PK_LENGTH]{};
 
-    if (CLI::stripKey(this->options.keyToCheck.c_str(), product_key) != 25) {
-        fmt::print("ERROR: Product key is not 25 valid characters!\n");
+    if (!CLI::stripKey(this->options.keyToCheck.c_str(), product_key)) {
+        fmt::print("ERROR: Product key is in an incorrect format!\n");
         return 1;
     }
 
@@ -400,8 +401,8 @@ int CLI::BINK1998Validate() {
 int CLI::BINK2002Validate() {
     char product_key[PK_LENGTH]{};
 
-    if (CLI::stripKey(this->options.keyToCheck.c_str(), product_key) != 25) {
-        fmt::print("ERROR: Product key is not 25 valid characters!\n");
+    if (!CLI::stripKey(this->options.keyToCheck.c_str(), product_key)) {
+        fmt::print("ERROR: Product key is in an incorrect format!\n");
         return 1;
     }
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -44,9 +44,12 @@ public:
     static int validateCommandLine(Options* options, char *argv[], json *keys);
     static void printID(DWORD *pid);
     static void printKey(char *pk);
+    static int stripKey(const char *in_key, char *out_key);
 
-    int BINK1998();
-    int BINK2002();
+    int BINK1998Generate();
+    int BINK2002Generate();
+    int BINK1998Validate();
+    int BINK2002Validate();
     int ConfirmationID();
 };
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -44,7 +44,7 @@ public:
     static int validateCommandLine(Options* options, char *argv[], json *keys);
     static void printID(DWORD *pid);
     static void printKey(char *pk);
-    static int stripKey(const char *in_key, char *out_key);
+    static bool stripKey(const char *in_key, char out_key[PK_LENGTH]);
 
     int BINK1998Generate();
     int BINK2002Generate();

--- a/src/header.h
+++ b/src/header.h
@@ -76,15 +76,18 @@ using json = nlohmann::json;
 namespace fs = std::filesystem;
 
 enum MODE {
-    MODE_BINK1998 = 0,
-    MODE_BINK2002 = 1,
+    MODE_BINK1998_GENERATE = 0,
+    MODE_BINK2002_GENERATE = 1,
     MODE_CONFIRMATION_ID = 2,
+    MODE_BINK1998_VALIDATE = 3,
+    MODE_BINK2002_VALIDATE = 4,
 };
 
 struct Options {
     std::string binkid;
     std::string keysFilename;
     std::string instid;
+    std::string keyToCheck;
     int channelID;
     int numKeys;
     bool verbose;
@@ -126,6 +129,7 @@ EC_GROUP *initializeEllipticCurve(
 );
 
 // key.cpp
+extern char pKeyCharset[25];
 void unbase24(BYTE *byteSeq, const char *cdKey);
 void base24(char *cdKey, BYTE *byteSeq);
 

--- a/src/header.h
+++ b/src/header.h
@@ -129,7 +129,7 @@ EC_GROUP *initializeEllipticCurve(
 );
 
 // key.cpp
-extern char pKeyCharset[25];
+extern char pKeyCharset[];
 void unbase24(BYTE *byteSeq, const char *cdKey);
 void base24(char *cdKey, BYTE *byteSeq);
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -23,7 +23,7 @@
 #include "header.h"
 
 /* The allowed character set in a product key. */
-char pKeyCharset[25] = "BCDFGHJKMPQRTVWXY2346789";
+char pKeyCharset[] = "BCDFGHJKMPQRTVWXY2346789";
 
 /* Converts from CD-key to a byte sequence. */
 void unbase24(BYTE *byteSeq, const char *cdKey) {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -22,7 +22,8 @@
 
 #include "header.h"
 
-char pCharset[] = "BCDFGHJKMPQRTVWXY2346789";
+/* The allowed character set in a product key. */
+char pKeyCharset[25] = "BCDFGHJKMPQRTVWXY2346789";
 
 /* Converts from CD-key to a byte sequence. */
 void unbase24(BYTE *byteSeq, const char *cdKey) {
@@ -34,7 +35,7 @@ void unbase24(BYTE *byteSeq, const char *cdKey) {
     // Remove dashes from the CD-key and put it into a Base24 byte array.
     for (int i = 0, k = 0; i < strlen(cdKey) && k < PK_LENGTH; i++) {
         for (int j = 0; j < 24; j++) {
-            if (cdKey[i] != '-' && cdKey[i] == pCharset[j]) {
+            if (cdKey[i] != '-' && cdKey[i] == pKeyCharset[j]) {
                 pDecodedKey[k++] = j;
                 break;
             }
@@ -82,7 +83,7 @@ void base24(char *cdKey, BYTE *byteSeq) {
     cdKey[25] = 0;
 
     for (int i = 24; i >= 0; i--)
-        cdKey[i] = pCharset[BN_div_word(z, 24)];
+        cdKey[i] = pKeyCharset[BN_div_word(z, 24)];
 
     BN_free(z);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,11 +42,17 @@ int main(int argc, char *argv[]) {
     CLI* run = new CLI(options, keys);
 
     switch(options.applicationMode) {
-        case MODE_BINK1998:
-            return run->BINK1998();
+        case MODE_BINK1998_GENERATE:
+            return run->BINK1998Generate();
 
-        case MODE_BINK2002:
-            return run->BINK2002();
+        case MODE_BINK2002_GENERATE:
+            return run->BINK2002Generate();
+
+        case MODE_BINK1998_VALIDATE:
+            return run->BINK1998Validate();
+
+        case MODE_BINK2002_VALIDATE:
+            return run->BINK2002Validate();
 
         case MODE_CONFIRMATION_ID:
             return run->ConfirmationID();


### PR DESCRIPTION
This adds a command line switch to validate (and print information of) a given key at the command line.

Additional changes:
- Added `CLI::stripKey` that strips extra characters of a given input key and outputs 25 uppercase chars of the key, as expected as input to other functions.
- Renamed `BINK1998`, `BINK2002` CLI functions / application modes to `BINK1998Generate` / `BINK2002Generate`, to make clear the distinction between the generation / validation behaviour.
- `BINK1998::Verify` now returns verbose information as `BINK2002::Verify` does.