### PR TITLE
Command line option to specify serial for generating BINK1998 keys

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -230,7 +230,7 @@ void CLI::printID(DWORD *pid)
     int i, digit = 0;
 
     // Convert PID to ascii-number (=raw)
-    sprintf(raw, "%u", pid[0]);
+    sprintf(raw, "%09u", pid[0]);
 
     // Make b-part {640-....}
     strncpy(b, raw, 3);

--- a/src/header.h
+++ b/src/header.h
@@ -89,6 +89,8 @@ struct Options {
     std::string instid;
     std::string keyToCheck;
     int channelID;
+    bool serialSet;
+    int serial;
     int numKeys;
     bool verbose;
     bool help;


### PR DESCRIPTION
Self-explanatory - allows for the generation of keys that have a user-specified serial in the product ID. Solely for cosmetic reasons, may cause issues with later products.

I'm not too familiar with how the product ID value is generated for BINK2002 keys so IDK whether anything similar could be added there.

![System info showing product ID of 727-7277273](https://github.com/UMSKT/UMSKT/assets/22731889/752621e8-495f-4c1b-885f-67d103ed52d8)
