### PR TITLE
Update Build Step for GitHub Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,8 +18,10 @@ jobs:
           sudo apt -y update
           sudo apt -y install build-essential cmake libssl-dev
 
-    - name: Build WindowsXPKg
-      uses: threeal/cmake-action@latest
+    - name: Configure and build WindowsXPKg
+      uses: threeal/cmake-action@v1.2.0
+      with:
+        run-build: true
 
     - name: Move files to correct directory
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1
 
+      - name: Configure WindowsXPKg
+        uses: threeal/cmake-action@v1.2.0
+
       - name: Build WindowsXPKg
-        run: |
-          cd build
-          cmake ../
-          msbuild ALL_BUILD.vcxproj /P:Configuration=Release
+        working-directory: build
+        run: msbuild ALL_BUILD.vcxproj /P:Configuration=Release
 
       - name: Copy files and clean up output directory
         run: |


### PR DESCRIPTION
Hi, as the author of the [CMake Action](https://github.com/threeal/cmake-action), I would like to inform you about a significant change in the latest version of the action. The updated version now focuses on CMake configuration without automatically building the project, unless the `run-build` input is explicitly specified.

In this pull request, I am making adjustments to the `Build WindowsXPKg` step. I have enabled the `run-build` option and replaced the `@latest` version tag with a fixed version `@v1.2.0`. This change ensures stability and prevents any future modifications in the `latest` branch from affecting the workflow.

Additionally, I have modified the `Build WindowsXPKg` step for Windows to utilize the CMake Action as well.