### PR TITLE
Add exclusions for FE and FF BINKs

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -216,9 +216,9 @@ int CLI::validateCommandLine(Options* options, char *argv[], json *keys) {
     int intBinkID;
     sscanf(options->binkid.c_str(), "%x", &intBinkID);
 
-    if (intBinkID >= 0x40 && intBinkID < 0xFE ) { // FE and FF are BINK 1998 
+    if (intBinkID >= 0x40 && intBinkID < 0xFE ) { // FE and FF are BINK 1998
         // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
-    	options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
+        options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
     }
 
     if (options->channelID > 999) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -217,6 +217,7 @@ int CLI::validateCommandLine(Options* options, char *argv[], json *keys) {
     sscanf(options->binkid.c_str(), "%x", &intBinkID);
 
     if (intBinkID >= 0x40 && intBinkID < 0xFE ) { // FE and FF are BINK 1998 
+        // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
     	options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
     }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -216,7 +216,13 @@ int CLI::validateCommandLine(Options* options, char *argv[], json *keys) {
     int intBinkID;
     sscanf(options->binkid.c_str(), "%x", &intBinkID);
 
-    if (intBinkID >= 0x40 && intBinkID < 0xFE ) { // FE and FF are BINK 1998
+    // FE and FF are BINK 1998, but do not generate valid keys, so we throw an error
+    if (intBinkID >= 0xFE) {
+        fmt::print("ERROR: Terminal Services BINKs (FE and FF) are unsupported at this time\n");
+        return 1;
+    }
+    
+    if (intBinkID >= 0x40) {
         // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
         options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
     }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -216,11 +216,8 @@ int CLI::validateCommandLine(Options* options, char *argv[], json *keys) {
     int intBinkID;
     sscanf(options->binkid.c_str(), "%x", &intBinkID);
 
-    if (intBinkID >= 0x40) {
-        if (intBinkID != 0xFE && intBinkID != 0xFF) { // FE and FF are oddballs that are bink1998, this excludes them from being set to bink2002
-	    // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
-            options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
-	}
+    if (intBinkID >= 0x40 && intBinkID < 0xFE ) { // FE and FF are BINK 1998 
+    	options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
     }
 
     if (options->channelID > 999) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -217,8 +217,10 @@ int CLI::validateCommandLine(Options* options, char *argv[], json *keys) {
     sscanf(options->binkid.c_str(), "%x", &intBinkID);
 
     if (intBinkID >= 0x40) {
-        // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
-        options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
+        if (intBinkID != 0xFE && intBinkID != 0xFF) { // FE and FF are oddballs that are bink1998, this excludes them from being set to bink2002
+	    // set bink2002 validate mode if in bink1998 validate mode, else set bink2002 generate mode
+            options->applicationMode = (options->applicationMode == MODE_BINK1998_VALIDATE) ? MODE_BINK2002_VALIDATE : MODE_BINK2002_GENERATE;
+	}
     }
 
     if (options->channelID > 999) {


### PR DESCRIPTION
FE and FF are 1998 BINKs, despite them being above 40. This excludes them from being marked as 2002 BINKs, lowering failure rates on key generation.