### PR TITLE
Make more consistent newlines

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -61,6 +61,7 @@ void CLI::showHelp(char *argv[]) {
     fmt::print("\t-s --serial\tspecifies a serial to use in the product ID (defaults to random, BINK1998 only)\n");
     fmt::print("\t-u --upgrade\tspecifies the Product Key will be an \"Upgrade\" version\n");
     fmt::print("\t-V --validate\tproduct key to validate signature\n");
+    fmt::print("\t-N --nonewline\tdisables newlines (for easier embedding in other apps)\n");
     fmt::print("\n");
 }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -82,13 +82,13 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
             false,
             false,
             false,
+	    false,
             MODE_BINK1998_GENERATE,
             WINDOWS
     };
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
-
         if (arg == "-v" || arg == "--verbose") {
             options->verbose = true;
             UMSKT::setDebugOutput(stderr);
@@ -194,7 +194,10 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
             options->keyToCheck = argv[i+1];
             options->applicationMode = MODE_BINK1998_VALIDATE;
             i++;
-        } else {
+		
+	} else if (arg == "-N" || arg == "--nonewline") {
+	    options->nonewlines = true;
+	} else {
             options->error = true;
         }
     }
@@ -447,10 +450,9 @@ int CLI::BINK1998Generate() {
     if (this->options.verbose) {
         fmt::print("\nSuccess count: {}/{}", this->count, this->total);
     }
-#ifndef _WIN32
-    fmt::print("\n");
-#endif
-
+    if (this->options.nonewline == false) {
+	fmt::print("\n"); 
+    }
     return 0;
 }
 
@@ -496,9 +498,9 @@ int CLI::BINK2002Generate() {
     if (this->options.verbose) {
         fmt::print("\nSuccess count: {}/{}", this->count, this->total);
     }
-#ifndef _WIN32
-    fmt::print("\n");
-#endif
+    if (this->options.nonewline == false) {
+	fmt::print("\n"); 
+    }
 
     return 0;
 }
@@ -572,9 +574,9 @@ int CLI::ConfirmationID() {
 
         case SUCCESS:
             fmt::print(confirmation_id);
-#ifndef _WIN32
-            fmt::print("\n");
-#endif
+    	    if (this->options.nonewline == false) {
+	        fmt::print("\n"); 
+    	    }
             return 0;
 
         default:

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -195,7 +195,7 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
             options->applicationMode = MODE_BINK1998_VALIDATE;
             i++;
 		
-	} else if (arg == "-N" || arg == "--nonewline") {
+	} else if (arg == "-N" || arg == "--nonewlines") {
 	    options->nonewlines = true;
 	} else {
             options->error = true;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -61,7 +61,7 @@ void CLI::showHelp(char *argv[]) {
     fmt::print("\t-s --serial\tspecifies a serial to use in the product ID (defaults to random, BINK1998 only)\n");
     fmt::print("\t-u --upgrade\tspecifies the Product Key will be an \"Upgrade\" version\n");
     fmt::print("\t-V --validate\tproduct key to validate signature\n");
-    fmt::print("\t-N --nonewline\tdisables newlines (for easier embedding in other apps)\n");
+    fmt::print("\t-N --nonewlines\tdisables newlines (for easier embedding in other apps)\n");
     fmt::print("\n");
 }
 
@@ -450,7 +450,7 @@ int CLI::BINK1998Generate() {
     if (this->options.verbose) {
         fmt::print("\nSuccess count: {}/{}", this->count, this->total);
     }
-    if (this->options.nonewline == false) {
+    if (this->options.nonewlines == false) {
 	fmt::print("\n"); 
     }
     return 0;
@@ -498,7 +498,7 @@ int CLI::BINK2002Generate() {
     if (this->options.verbose) {
         fmt::print("\nSuccess count: {}/{}", this->count, this->total);
     }
-    if (this->options.nonewline == false) {
+    if (this->options.nonewlines == false) {
 	fmt::print("\n"); 
     }
 
@@ -574,7 +574,7 @@ int CLI::ConfirmationID() {
 
         case SUCCESS:
             fmt::print(confirmation_id);
-    	    if (this->options.nonewline == false) {
+    	    if (this->options.nonewlines == false) {
 	        fmt::print("\n"); 
     	    }
             return 0;

--- a/src/cli.h
+++ b/src/cli.h
@@ -67,6 +67,7 @@ struct Options {
     bool help;
     bool error;
     bool list;
+    bool nonewlines;
 
     MODE applicationMode;
     ACTIVATION_ALGORITHM activationMode;


### PR DESCRIPTION
Instead of only giving newlines at the end on Linux, it can give newlines all the time unless specified not to.

The reason why newlines are a problem in some cases is that it can cause issues with other programs that use UMSKT, not expecting newlines. The --nonewlines argument can fix that.