### PR TITLE
Usage validation and memleaks fixes

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -207,7 +207,7 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
     }
 
     // make sure that a product id is entered for OFFICE_2K3 or OFFICE_2K7 IIDs
-    if ((options->activationMode == OFFICE_2K3 || options->activationMode == OFFICE_2K7) && options->productid == "") {
+    if ((options->activationMode == OFFICE_2K3 || options->activationMode == OFFICE_2K7) && (options->productid.empty() || options->instid.empty()) ) {
         return options->error = true;
     }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -183,6 +183,10 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
 	    }
             i++;
         } else if (arg == "-p" || arg == "--productid") {
+	    if (i == argc -1) {
+                options->error = true;
+                break;
+	    }
             options->productid = argv[i+1];
             i++;
         } else if (arg == "-V" || arg == "--validate") {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -22,6 +22,15 @@
 
 #include "cli.h"
 
+CLI::~CLI()
+{
+    EC_GROUP_free(eCurve);
+    EC_POINT_free(genPoint);
+    EC_POINT_free(pubPoint);
+    BN_free(privateKey);
+    BN_free(genOrder);
+}
+
 bool CLI::loadJSON(const fs::path& filename, json *output) {
     if (!filename.empty() && !fs::exists(filename)) {
         fmt::print("ERROR: File {} does not exist\n", filename.string());
@@ -417,6 +426,7 @@ int CLI::BINK1998Generate() {
 
         sscanf(cRaw, "%d", &oRaw);
         nRaw += (oRaw % 999999); // ensure our serial is less than 999999
+	BN_free(bnrand);
     }
 
     if (this->options.verbose) {

--- a/src/cli.h
+++ b/src/cli.h
@@ -85,6 +85,7 @@ class CLI {
 
 public:
     CLI(Options options, json keys);
+    ~CLI();
 
     static bool loadJSON(const fs::path& filename, json *output);
     static void showHelp(char *argv[]);

--- a/src/libumskt/pidgen3/util.cpp
+++ b/src/libumskt/pidgen3/util.cpp
@@ -100,6 +100,13 @@ EC_GROUP* PIDGEN3::initializeEllipticCurve(
 
     // Cleanup
     BN_CTX_free(context);
+    BN_free(p);
+    BN_free(a);
+    BN_free(b);
+    BN_free(generatorX);
+    BN_free(generatorY);
+    BN_free(publicKeyX);
+    BN_free(publicKeyY);
 
     return eCurve;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,23 +39,23 @@ int main(int argc, char *argv[]) {
         return status;
     }
 
-    CLI* run = new CLI(options, keys);
+    CLI run(options, keys);
 
     switch(options.applicationMode) {
         case MODE_BINK1998_GENERATE:
-            return run->BINK1998Generate();
+            return run.BINK1998Generate();
 
         case MODE_BINK2002_GENERATE:
-            return run->BINK2002Generate();
+            return run.BINK2002Generate();
 
         case MODE_BINK1998_VALIDATE:
-            return run->BINK1998Validate();
+            return run.BINK1998Validate();
 
         case MODE_BINK2002_VALIDATE:
-            return run->BINK2002Validate();
+            return run.BINK2002Validate();
 
         case MODE_CONFIRMATION_ID:
-            return run->ConfirmationID();
+            return run.ConfirmationID();
 
         default:
             return 1;


### PR DESCRIPTION
* `-p` ensure parameter provided to prevent core dump
* number of memleaks when using `BN_new` and `EC_*_free`