### PR TITLE
cleanup CMakeLists.txt

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,6 +50,7 @@ jobs:
           musl-dev
           openssl-dev
           openssl-libs-static
+          zlib-dev
         arch: ${{ matrix.arch }}
         shell-name: alpine-target.sh
 
@@ -70,3 +71,17 @@ jobs:
       with:
         name: UMSKT-linux-${{ matrix.arch }}-static
         path: build/actions_upload
+
+    - name: Configure and build static internal deps UMSKT
+      uses: threeal/cmake-action@7ef2eb8da6e5ec0a6de6b1ddc96987080bed06e8
+      with:
+        options: MUSL_STATIC=OFF BUILD_SHARED_LIBS=OFF
+        run-build: true
+        shell: alpine-target.sh {0}
+
+    - name: Configure and build shared deps UMSKT
+      uses: threeal/cmake-action@7ef2eb8da6e5ec0a6de6b1ddc96987080bed06e8
+      with:
+        options: MUSL_STATIC=OFF BUILD_SHARED_LIBS=ON
+        run-build: true
+        shell: alpine-target.sh {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,11 +52,11 @@ jobs:
               exit 1
           }
 
-      - name: Download And Install 32-bit OpenSSL 3.1.2
+      - name: Download And Install 32-bit OpenSSL 3.1.3
         run: |
           $installDir = "$Env:ProgramFiles\OpenSSL"
-          $installerURL = "https://slproweb.com/download/Win32OpenSSL-3_1_2.exe"
-          $installerName = "Win32OpenSSL-3_1_2.exe"
+          $installerURL = "https://slproweb.com/download/Win32OpenSSL-3_1_3.exe"
+          $installerName = "Win32OpenSSL-3_1_3.exe"
           $installerPath = Join-Path -Path "${env:Temp}" -ChildPath "$installerName"
 
           (New-Object System.Net.WebClient).DownloadFile($installerURL, $installerPath)
@@ -112,11 +112,11 @@ jobs:
               exit 1
           }
     
-      - name: Download And Install 64-bit OpenSSL 3.1.2
+      - name: Download And Install 64-bit OpenSSL 3.1.3
         run: |
           $installDir = "$Env:ProgramFiles\OpenSSL"
-          $installerURL = "https://slproweb.com/download/Win64OpenSSL-3_1_2.exe"
-          $installerName = "Win64OpenSSL-3_1_2.exe"
+          $installerURL = "https://slproweb.com/download/Win64OpenSSL-3_1_3.exe"
+          $installerName = "Win64OpenSSL-3_1_3.exe"
           $installerPath = Join-Path -Path "${env:Temp}" -ChildPath "$installerName"
 
           (New-Object System.Net.WebClient).DownloadFile($installerURL, $installerPath)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   MESSAGE(STATUS "[UMSKT] macOS has no static library - Shared library forced on")
 endif()
 
-if (DJGPP_WATT32)
-  SET(BUILD_SHARED_LIBS ON)
-  MESSAGE(STATUS "[UMSKT] DOS has no static library - Shared library forced on")
-endif()
-
 # if we're compiling with MSVC, respect the DEBUG compile option
 IF(MSVC)
     SET(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,11 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
 PROJECT(UMSKT)
+
 SET(CMAKE_CXX_STANDARD 17)
-SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 SET(CMAKE_OSX_SYSROOT "macosx" CACHE PATH "macOS SDK path")
+
+OPTION(BUILD_SHARED_LIBS "Build internal libraries as dynamic" OFF)
 OPTION(UMSKT_USE_SHARED_OPENSSL "Force linking against the system-wide OpenSSL library" OFF)
 OPTION(MUSL_STATIC "Enable fully static builds in a muslc environment (i.e. Alpine Linux)" OFF)
 OPTION(DJGPP_WATT32 "Enable compilation and linking with DJGPP/WATT32/OpenSSL" OFF)
@@ -44,10 +46,11 @@ endif()
 IF(UMSKT_USE_SHARED_OPENSSL)
     SET(OPENSSL_USE_STATIC_LIBS FALSE)
     SET(OPENSSL_MSVC_STATIC_RT FALSE)
-    MESSAGE(WARNING "[UMSKT] Forcing shared OpenSSL runtime")
+    MESSAGE(STATUS "[UMSKT] Requesting dynamic version of OpenSSL")
 ELSE()
     SET(OPENSSL_USE_STATIC_LIBS TRUE)
     SET(OPENSSL_MSVC_STATIC_RT TRUE)
+    MESSAGE(STATUS "[UMSKT] Requesting static version of OpenSSL")
 ENDIF()
 
 
@@ -60,24 +63,6 @@ IF(DJGPP_WATT32)
     SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
     SET(UMSKT_LINK_LIBS ${UMSKT_LINK_LIBS} ${DJGPP_WATT32})
     SET(UMSKT_LINK_DIRS ${UMSKT_LINK_DIRS} ${WATT_ROOT}/lib)
-ENDIF()
-
-# find the system installed OpenSSL development library
-FIND_PACKAGE(OpenSSL REQUIRED)
-IF(NOT OPENSSL_FOUND)
-    MESSAGE(SEND_ERROR "OpenSSL Development Libraries Not Found")
-    MESSAGE(SEND_ERROR "Please consult your package manager of choice to install the prerequisite")
-    MESSAGE(SEND_ERROR "The package name is commonly called libssl-dev or openssl-dev depending on distribution")
-    MESSAGE(FATAL_ERROR "Can not continue without OpenSSL")
-ENDIF()
-
-# if we found shared libraries - do the following:
-STRING(REGEX MATCH "(\\.so|\\.dll|\\.dylib)$" OPENSSL_CRYPTO_SHARED "${OPENSSL_CRYPTO_LIBRARY}")
-IF(OPENSSL_CRYPTO_SHARED)
-    MESSAGE(STATUS "[UMSKT] Detected Shared library version of OpenSSL")
-    SET(BUILD_SHARED_LIBS ON)
-ELSE()
-    MESSAGE(STATUS "[UMSKT] Detected Static Library version of OpenSSL")
 ENDIF()
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -108,11 +93,54 @@ ENDIF()
 
 IF(MUSL_STATIC)
     MESSAGE(STATUS "[UMSKT] Performing a fully static build using muslc")
+    SET(BUILD_SHARED_LIBS OFF)
+    SET(OPENSSL_USE_STATIC_LIBS TRUE)
+
     SET(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
     SET(CMAKE_SHARED_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
     SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc -static-libstdc++")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
+ENDIF()
+
+# find the system installed OpenSSL development library
+FIND_PACKAGE(OpenSSL REQUIRED)
+IF(NOT OPENSSL_FOUND)
+    MESSAGE(SEND_ERROR "OpenSSL Development Libraries Not Found")
+    MESSAGE(SEND_ERROR "Please consult your package manager of choice to install the prerequisite")
+    MESSAGE(SEND_ERROR "The package name is commonly called libssl-dev or openssl-dev depending on distribution")
+    MESSAGE(FATAL_ERROR "Can not continue without OpenSSL")
+ENDIF()
+
+IF(NOT MUSL_STATIC)
+    # if we found shared libraries - do the following:
+    IF (OPENSSL_USE_STATIC_LIBS)
+	MESSAGE(STATUS "[UMSKT] requested static version of OpenSSL")
+	if (NOT UMSKT_USE_SHARED_OPENSSL)
+	    MESSAGE(STATUS "[UMSKT] not asked for shared version of OpenSSL")
+	ENDIF()
+
+	IF(MSVC)
+	    SET(UMSKT_LINK_LIBS ${UMSKT_LINK_LIBS} "ws2_32.lib")
+	    SET(UMSKT_LINK_LIBS ${UMSKT_LINK_LIBS} "crypt32.lib")
+	    MESSAGE(STATUS "[UMSKT] msvc adding ws2_32.lib crypt32.lib")
+	ENDIF()
+    ENDIF()
+
+    STRING(REGEX MATCH "(\\.so|\\.dll|\\.dylib)$" OPENSSL_CRYPTO_SHARED "${OPENSSL_CRYPTO_LIBRARY}")
+    IF(OPENSSL_CRYPTO_SHARED)
+	MESSAGE(STATUS "[UMSKT] Detected Shared library version of OpenSSL")
+    ELSE()
+	MESSAGE(STATUS "[UMSKT] Detected Static Library version of OpenSSL")
+
+	# static libcrypto on Fedora needs -lz at link time
+	IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	    FIND_PACKAGE(ZLIB REQUIRED)
+	    IF (NOT ZLIB_FOUND)
+		MESSAGE(FATAL_ERROR "[UMSKT] linux static OpenSSL requires zlib")
+	    ENDIF()
+	ENDIF()
+    ENDIF()
 ENDIF()
 
 # initalize cpm.CMake
@@ -174,26 +202,22 @@ IF (EMSCRIPTEN)
     SET_TARGET_PROPERTIES(umskt PROPERTIES COMPILE_FLAGS "-Os -sEXPORTED_RUNTIME_METHODS=ccall,cwrap")
     SET_TARGET_PROPERTIES(umskt PROPERTIES LINK_FLAGS    "-Os -sWASM=1 -sEXPORT_ALL=1 -sEXPORTED_RUNTIME_METHODS=ccall,cwrap --no-entry")
 ELSE()
-    IF(NOT UMSKT_USE_SHARED_OPENSSL)
-        ### Static library compilation
-        ADD_LIBRARY(_umskt STATIC ${LIBUMSKT_SRC})
-        TARGET_INCLUDE_DIRECTORIES(_umskt PUBLIC ${OPENSSL_INCLUDE_DIR})
-        TARGET_LINK_LIBRARIES(_umskt -static OpenSSL::Crypto fmt ${UMSKT_LINK_LIBS})
-    ELSE()
-        ### Shared library compilation
-        ADD_LIBRARY(_umskt SHARED ${LIBUMSKT_SRC} ${UMSKT_EXE_WINDOWS_EXTRA} ${UMSKT_EXE_WINDOWS_DLL})
-        TARGET_INCLUDE_DIRECTORIES(_umskt PUBLIC ${OPENSSL_INCLUDE_DIR})
-        TARGET_LINK_LIBRARIES(_umskt OpenSSL::Crypto fmt ${UMSKT_LINK_LIBS})
-        TARGET_LINK_DIRECTORIES(_umskt PUBLIC ${UMSKT_LINK_DIRS})
-    ENDIF()
+    ADD_LIBRARY(_umskt ${LIBUMSKT_SRC} ${UMSKT_EXE_WINDOWS_EXTRA} ${UMSKT_EXE_WINDOWS_DLL})
+    TARGET_INCLUDE_DIRECTORIES(_umskt PUBLIC ${OPENSSL_INCLUDE_DIR})
+    TARGET_LINK_DIRECTORIES(_umskt PUBLIC ${UMSKT_LINK_DIRS})
+    TARGET_LINK_LIBRARIES(_umskt ${OPENSSL_CRYPTO_LIBRARIES} fmt ${UMSKT_LINK_LIBS})
 
     ### UMSKT executable compilation
     ADD_EXECUTABLE(umskt src/main.cpp src/cli.cpp ${UMSKT_EXE_WINDOWS_EXTRA})
     TARGET_INCLUDE_DIRECTORIES(umskt PUBLIC ${OPENSSL_INCLUDE_DIR})
-    TARGET_LINK_LIBRARIES(umskt _umskt OpenSSL::Crypto fmt nlohmann_json::nlohmann_json umskt::rc ${UMSKT_LINK_LIBS})
+    TARGET_LINK_LIBRARIES(umskt _umskt ${OPENSSL_CRYPTO_LIBRARIES} ${ZLIB_LIBRARIES} fmt nlohmann_json::nlohmann_json umskt::rc ${UMSKT_LINK_LIBS})
     TARGET_LINK_DIRECTORIES(umskt PUBLIC ${UMSKT_LINK_DIRS})
     IF(MSVC AND MSVC_MSDOS_STUB)
         SET_PROPERTY(TARGET umskt APPEND PROPERTY LINK_FLAGS /STUB:${MSVC_MSDOS_STUB})
+    ENDIF()
+
+    IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        install(TARGETS umskt DESTINATION bin)
     ENDIF()
 
     ### Copy Shared Libraries and dependency files


### PR DESCRIPTION
Normal users building do not want internal `lib_umskt.so` shared library in a build if they specify `-DBUILD_SHARED_LIBS=0` - this will produce static archives for all internal deps and links a binary that is a normal linux binary (not fully static) and thus can be installed into /usr/local/bin etc
```
mkdir build && cd build
cmake \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_SHARED_LIBS=0 \
    -DUMSKT_USE_SHARED_OPENSSL=1 \
    -DOPENSSL_CRYPTO_LIBRARY=/usr/lib64/libcrypto.so \
    -DOPENSSL_LIBRARY=/usr/lib64/libssl.so \
  ../
make -j
```

This cleans up `CMakeLists.txt` for some redudant params and uses the cmake equivs (no need for static / dynamic library defns etc).

