### PR TITLE
Override version check for confirmation ID's

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -214,7 +214,6 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
 	    options->nonewlines = true;
 	} else if (arg == "-o" || arg == "--override") {
 	    options->overrideVersion = true;
-	}
 	} else {
             options->error = true;
         }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -71,6 +71,7 @@ void CLI::showHelp(char *argv[]) {
     fmt::print("\t-u --upgrade\tspecifies the Product Key will be an \"Upgrade\" version\n");
     fmt::print("\t-V --validate\tproduct key to validate signature\n");
     fmt::print("\t-N --nonewlines\tdisables newlines (for easier embedding in other apps)\n");
+    fmt::print("\t-o --override\tDisables version check for confirmation ID's, if you need this send a pull request");
     fmt::print("\n");
 }
 
@@ -91,6 +92,7 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
             false,
             false,
             false,
+	    false,
 	    false,
             MODE_BINK1998_GENERATE,
             WINDOWS
@@ -210,6 +212,9 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
 		
 	} else if (arg == "-N" || arg == "--nonewlines") {
 	    options->nonewlines = true;
+	} else if (arg == "-o" || arg == "--override") {
+	    options->override = true;
+	}
 	} else {
             options->error = true;
         }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -564,7 +564,7 @@ int CLI::BINK2002Validate() {
 
 int CLI::ConfirmationID() {
     char confirmation_id[49];
-    int err = ConfirmationID::Generate(this->options.instid.c_str(), confirmation_id, options.activationMode, options.productid);
+    int err = ConfirmationID::Generate(this->options.instid.c_str(), confirmation_id, options.activationMode, options.productid, options.overrideVersion);
 
     switch (err) {
         case ERR_TOO_SHORT:

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -213,7 +213,7 @@ int CLI::parseCommandLine(int argc, char* argv[], Options* options) {
 	} else if (arg == "-N" || arg == "--nonewlines") {
 	    options->nonewlines = true;
 	} else if (arg == "-o" || arg == "--override") {
-	    options->override = true;
+	    options->overrideVersion = true;
 	}
 	} else {
             options->error = true;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -71,7 +71,7 @@ void CLI::showHelp(char *argv[]) {
     fmt::print("\t-u --upgrade\tspecifies the Product Key will be an \"Upgrade\" version\n");
     fmt::print("\t-V --validate\tproduct key to validate signature\n");
     fmt::print("\t-N --nonewlines\tdisables newlines (for easier embedding in other apps)\n");
-    fmt::print("\t-o --override\tDisables version check for confirmation ID's, if you need this send a pull request");
+    fmt::print("\t-o --override\tDisables version check for confirmation ID's, if you need this send an issue on GitHub");
     fmt::print("\n");
 }
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -68,7 +68,7 @@ struct Options {
     bool error;
     bool list;
     bool nonewlines;
-    bool override;
+    bool overrideVersion;
 
     MODE applicationMode;
     ACTIVATION_ALGORITHM activationMode;

--- a/src/cli.h
+++ b/src/cli.h
@@ -68,6 +68,7 @@ struct Options {
     bool error;
     bool list;
     bool nonewlines;
+    bool override;
 
     MODE applicationMode;
     ACTIVATION_ALGORITHM activationMode;

--- a/src/libumskt/confid/confid.cpp
+++ b/src/libumskt/confid/confid.cpp
@@ -773,7 +773,7 @@ void ConfirmationID::Unmix(unsigned char* buffer, size_t bufSize, const unsigned
 	}
 }
 
-int ConfirmationID::Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid)
+int ConfirmationID::Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid, bool overrideVersion)
 {
 	int version;
 	unsigned char hardwareID[8];
@@ -870,8 +870,8 @@ int ConfirmationID::Generate(const char* installation_id_str, char confirmation_
 			iid_key[3] = 0xF3;
 	}
 	Unmix(installation_id, totalCount == 41 ? 17 : 19, iid_key, 4);
-	//if (installation_id[18] >= 0x10)
-	//	return ERR_UNKNOWN_VERSION;
+	if (installation_id[18] >= 0x10 && overrideVersion == false)
+		return ERR_UNKNOWN_VERSION;
 
 #pragma pack(push, 1)
 	struct {
@@ -891,32 +891,38 @@ int ConfirmationID::Generate(const char* installation_id_str, char confirmation_
 			productID[2] = (parsed.ProductIDLow >> 27) & ((1 << 24) - 1);
 			version    = (parsed.ProductIDLow >> 51) & 15;
 			productID[3] = (parsed.ProductIDLow >> 55) | (parsed.ProductIDHigh << 9);
-			//switch (activationMode) {
-			//	case 0:
-			//		if (version != (totalCount == 41 ? 9 : 10))
-			//			return ERR_UNKNOWN_VERSION;
-			//		break;
-			//	case 1:
-			//		if (version != 1)
-			//			return ERR_UNKNOWN_VERSION;
-			//		break;
-			//	case 3:
-			//		if (version != 4)
-			//			return ERR_UNKNOWN_VERSION;
-			//}
+			if (overrideVersion == false) {
+			        switch (activationMode) {
+					case 0:
+						if (version != (totalCount == 41 ? 9 : 10))
+							return ERR_UNKNOWN_VERSION;
+						break;
+					case 1:
+						if (version != 1)
+							return ERR_UNKNOWN_VERSION;
+						break;
+					case 3:
+						if (version != 4)
+							return ERR_UNKNOWN_VERSION;
+				}
+			}
+
 			break;
 		case 2:
 		case 3:
 			decode_iid_new_version(installation_id, hardwareID, &version);
-			//switch (activationMode) {
-			//	case 2:
-			//		if (version != 3)
-			//			return ERR_UNKNOWN_VERSION;
-			//		break;
-			//	case 3:
-			//		if (version != 4)
-			//			return ERR_UNKNOWN_VERSION;
-			//}
+			if (overrideVersion == false) {
+			    switch (activationMode) {
+			    	case 2:
+			    		if (version != 3)
+				    		return ERR_UNKNOWN_VERSION;
+			    		break;
+		                case 3:
+					if (version != 4)
+						return ERR_UNKNOWN_VERSION;
+				        break;
+			    }
+			}
 			memcpy(&parsed, hardwareID, 8);
 			productID[0] = stoi(productid.substr(0,5));
 			std::string channelid = productid.substr(6,3);

--- a/src/libumskt/confid/confid.cpp
+++ b/src/libumskt/confid/confid.cpp
@@ -870,8 +870,8 @@ int ConfirmationID::Generate(const char* installation_id_str, char confirmation_
 			iid_key[3] = 0xF3;
 	}
 	Unmix(installation_id, totalCount == 41 ? 17 : 19, iid_key, 4);
-	if (installation_id[18] >= 0x10)
-		return ERR_UNKNOWN_VERSION;
+	//if (installation_id[18] >= 0x10)
+	//	return ERR_UNKNOWN_VERSION;
 
 #pragma pack(push, 1)
 	struct {
@@ -891,32 +891,32 @@ int ConfirmationID::Generate(const char* installation_id_str, char confirmation_
 			productID[2] = (parsed.ProductIDLow >> 27) & ((1 << 24) - 1);
 			version    = (parsed.ProductIDLow >> 51) & 15;
 			productID[3] = (parsed.ProductIDLow >> 55) | (parsed.ProductIDHigh << 9);
-			switch (activationMode) {
-				case 0:
-					if (version != (totalCount == 41 ? 9 : 10))
-						return ERR_UNKNOWN_VERSION;
-					break;
-				case 1:
-					if (version != 1)
-						return ERR_UNKNOWN_VERSION;
-					break;
-				case 3:
-					if (version != 4)
-						return ERR_UNKNOWN_VERSION;
-			}
+			//switch (activationMode) {
+			//	case 0:
+			//		if (version != (totalCount == 41 ? 9 : 10))
+			//			return ERR_UNKNOWN_VERSION;
+			//		break;
+			//	case 1:
+			//		if (version != 1)
+			//			return ERR_UNKNOWN_VERSION;
+			//		break;
+			//	case 3:
+			//		if (version != 4)
+			//			return ERR_UNKNOWN_VERSION;
+			//}
 			break;
 		case 2:
 		case 3:
 			decode_iid_new_version(installation_id, hardwareID, &version);
-			switch (activationMode) {
-				case 2:
-					if (version != 3)
-						return ERR_UNKNOWN_VERSION;
-					break;
-				case 3:
-					if (version != 4)
-						return ERR_UNKNOWN_VERSION;
-			}
+			//switch (activationMode) {
+			//	case 2:
+			//		if (version != 3)
+			//			return ERR_UNKNOWN_VERSION;
+			//		break;
+			//	case 3:
+			//		if (version != 4)
+			//			return ERR_UNKNOWN_VERSION;
+			//}
 			memcpy(&parsed, hardwareID, 8);
 			productID[0] = stoi(productid.substr(0,5));
 			std::string channelid = productid.substr(6,3);

--- a/src/libumskt/confid/confid.h
+++ b/src/libumskt/confid/confid.h
@@ -66,7 +66,7 @@ EXPORT class ConfirmationID {
     static void Unmix(unsigned char* buffer, size_t bufSize, const unsigned char* key, size_t keySize);
 
 public:
-    static int Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid);
+    static int Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid, bool overrideVersion);
     //EXPORT static int CLIRun();
 };
 

--- a/src/libumskt/libumskt.cpp
+++ b/src/libumskt/libumskt.cpp
@@ -27,8 +27,8 @@
 #include "pidgen3/BINK2002.h"
 #include "pidgen2/PIDGEN2.h"
 
-FNEXPORT int ConfirmationID_Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid) {
-    return ConfirmationID::Generate(installation_id_str, confirmation_id, mode, productid);
+FNEXPORT int ConfirmationID_Generate(const char* installation_id_str, char confirmation_id[49], int mode, std::string productid, bool bypassVersion) {
+    return ConfirmationID::Generate(installation_id_str, confirmation_id, mode, productid, bypassVersion);
 }
 
 FNEXPORT EC_GROUP* PIDGEN3_initializeEllipticCurve(char* pSel, char* aSel, char* bSel, char* generatorXSel, char* generatorYSel, char* publicKeyXSel, char* publicKeyYSel, EC_POINT *&genPoint, EC_POINT *&pubPoint) {


### PR DESCRIPTION
Temporary fix for Office 2007 not generating confirmation ID's as it falsely gives the "Unknown installation ID version." error.