### PR TITLE
[Neo-Desktop Refactor] [CLI] off-by-one fix and flavour pidgen type override

### DIFF
--- a/src/cli/help.cpp
+++ b/src/cli/help.cpp
@@ -250,7 +250,7 @@ BOOL CLI::processOptions()
         goto processOptionsExitEarly;
     }
 
-    if (flavour["meta"]["type"] == "PIDGEN3")
+    if (product["meta"]["type"] == "PIDGEN3")
     {
         options.pidgenversion = Options::PIDGEN_VERSION::PIDGEN_3;
         if (options.verbose)
@@ -272,7 +272,7 @@ BOOL CLI::processOptions()
             fmt::print("Selected BINK: {}\n", options.binkID);
         }
     }
-    else if (flavour["meta"]["type"] == "PIDGEN2")
+    else if (product["meta"]["type"] == "PIDGEN2")
     {
         options.pidgenversion = Options::PIDGEN_VERSION::PIDGEN_2;
         if (options.verbose)
@@ -544,7 +544,7 @@ BOOL CLI::SetChannelIDOption(const std::string &channum)
     Integer channelID = UMSKT::IntegerS(channum);
 
     // channel ids must be between 000 and 999
-    if (channelID > PIDGEN::MaxChannelID)
+    if (channelID >= PIDGEN::MaxChannelID)
     {
         fmt::print("ERROR: refusing to create a key with a Channel ID greater than 999\n");
         return false;
@@ -588,7 +588,7 @@ BOOL CLI::SetSerialOption(const std::string &arg)
     Integer Serial = UMSKT::IntegerS(arg);
 
     // serials must be between 000000 and 999999
-    if (Serial > PIDGEN::MaxSerial)
+    if (Serial >= PIDGEN::MaxSerial)
     {
         fmt::print("ERROR: refusing to create a key with a Serial not between 000000 and 999999\n");
         return false;

--- a/src/cli/help.cpp
+++ b/src/cli/help.cpp
@@ -244,13 +244,19 @@ BOOL CLI::processOptions()
         flavour = product;
     }
 
+    auto pidtype = product["meta"]["type"];
+    if (flavour["meta"].contains("type"))
+    {
+        pidtype = flavour["meta"]["type"];
+    }
+
     if (options.state != Options::STATE_PIDGEN_GENERATE && options.state != Options::STATE_PIDGEN_VALIDATE)
     {
         // exit early if we're not doing PIDGEN
         goto processOptionsExitEarly;
     }
 
-    if (product["meta"]["type"] == "PIDGEN3")
+    if (pidtype == "PIDGEN3")
     {
         options.pidgenversion = Options::PIDGEN_VERSION::PIDGEN_3;
         if (options.verbose)
@@ -272,7 +278,7 @@ BOOL CLI::processOptions()
             fmt::print("Selected BINK: {}\n", options.binkID);
         }
     }
-    else if (product["meta"]["type"] == "PIDGEN2")
+    else if (pidtype == "PIDGEN2")
     {
         options.pidgenversion = Options::PIDGEN_VERSION::PIDGEN_2;
         if (options.verbose)

--- a/src/cli/pidgen.cpp
+++ b/src/cli/pidgen.cpp
@@ -59,7 +59,7 @@ BOOL CLI::InitPIDGEN3(PIDGEN3 *p3)
         options.channelID.Randomize(UMSKT::rng, sizeof(DWORD32) * 8);
     }
 
-    options.channelID %= 999;
+    options.channelID %= 1000;
     p3->info.ChannelID = options.channelID;
     if (options.verbose)
     {
@@ -162,7 +162,7 @@ BOOL CLI::PIDGEN3Generate(PIDGEN3 *p3)
         }
 
         // make sure it's less than 999999
-        serialRnd %= 999999;
+        serialRnd %= 1000000;
     }
 
     p3->info.isOEM = options.oem;


### PR DESCRIPTION
* Add 1 to modulus operations, fixes user-supplied all-nines channel IDs and serial numbers

* Use product instead of flavor when checking pidgen type (fixes BINK ID autoselection for products with flavors)

* Fix sanity check for invalid serial and channel ID

(Note: At this time, this makes user-supplied all-zeros channel IDs and serial numbers not accessible outside of RNG luck. I do plan on addressing this somehow.)