### PR TITLE
Disable automatic FreeBSD GH action

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -21,12 +21,12 @@
  name: C/C++ CI (FreeBSD) 
   
  on: 
-  push:
-    branches: [ "*" ]
-    paths-ignore: [ '**.md', 'doc/**', '.idea/**'] # If only these files are edited, skip
-  pull_request:
-    branches: [ "*" ]
-    paths-ignore: [ '**.md', 'doc/**', '.idea/**'] # If only these files are edited, skip
+  #push:
+  #  branches: [ "*" ]
+  #  paths-ignore: [ '**.md', 'doc/**', '.idea/**'] # If only these files are edited, skip
+  #pull_request:
+  #  branches: [ "*" ]
+  #  paths-ignore: [ '**.md', 'doc/**', '.idea/**'] # If only these files are edited, skip
 
   workflow_dispatch:
   


### PR DESCRIPTION
So far, it's hit or miss on if UMSKT compiles or not for FreeBSD, being completely random (even if the code doesn't change, it can randomly fail or succeed). I don't think anyone actually needs FreeBSD support for this, so I'm proposing it only executes from a manual workflow dispatch command.