### PR TITLE
Replace MSVC with TDM-GCC

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,6 +72,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export PATH="/c/TDM-GCC-64/bin:$PATH"
+          export OPENSSL_PREFIX="${GITHUB_WORKSPACE}/openssl-install-64"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
@@ -82,23 +83,25 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure UMSKT (TDM-GCC 64-bit)
-        shell: msys2 {0}
+        shell: pwsh
         run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          cmake -G "MinGW Makefiles" \
-            -DCMAKE_C_COMPILER="mingw-w64-x86_64-gcc" \
-            -DCMAKE_CXX_COMPILER="mingw-w64-x86_64-g++" \
-            -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}" \
-            -DOPENSSL_INCLUDE_DIR="${OPENSSL_PREFIX}/include" \
-            -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_PREFIX}/lib/libcrypto.a" \
-            -DOPENSSL_SSL_LIBRARY="${OPENSSL_PREFIX}/lib/libssl.a" \
-            -DCMAKE_C_FLAGS="-m64" \
-            -DCMAKE_CXX_FLAGS="-m64" \
+          $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
+          cmake -G "MinGW Makefiles" `
+            -DCMAKE_C_COMPILER="gcc" `
+            -DCMAKE_CXX_COMPILER="g++" `
+            -DOPENSSL_ROOT_DIR="${env:GITHUB_WORKSPACE}/openssl-install-64" `
+            -DOPENSSL_INCLUDE_DIR="${env:GITHUB_WORKSPACE}/openssl-install-64/include" `
+            -DOPENSSL_CRYPTO_LIBRARY="${env:GITHUB_WORKSPACE}/openssl-install-64/lib/libcrypto.a" `
+            -DOPENSSL_SSL_LIBRARY="${env:GITHUB_WORKSPACE}/openssl-install-64/lib/libssl.a" `
+            -DCMAKE_C_FLAGS="-m64" `
+            -DCMAKE_CXX_FLAGS="-m64" `
             .
 
       - name: Build UMSKT (TDM-GCC 64-bit)
-        shell: msys2 {0}
-        run: make
+        shell: pwsh
+        run: |
+          $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
+          mingw32-make
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,9 +79,6 @@ jobs:
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
           make -j$(nproc)
           make install_sw
-          ls -l "$OPENSSL_PREFIX"
-          ls -l "$OPENSSL_PREFIX/lib"
-          ls -l "$OPENSSL_PREFIX/include"
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4
@@ -91,10 +88,8 @@ jobs:
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
           $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
-          $OPENSSL_LIB = "$OPENSSL_ROOT"
+          $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
-          Get-ChildItem -Recurse $env:GITHUB_WORKSPACE\openssl-install-64
-          throw "Testing"
 
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
             make
             perl
             nasm
-            mingw-w64-x86_64-tree
+            tree
 
       - name: Cache OpenSSL 64-bit build
         id: cache-openssl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export PATH="/c/TDM-GCC-64/bin:$PATH"
-          export OPENSSL_PREFIX="$(pwd)/openssl-install-64"
+          export OPENSSL_PREFIX="$(cygpath -w "$GITHUB_WORKSPACE")\\openssl-install-64"
           echo "OPENSSL_PREFIX is: $OPENSSL_PREFIX"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,6 +85,6 @@ jobs:
         uses: actions/upload-artifact@v4.6.2
         with:
           name: UMSKT-TDM64
-          path: ./Release/*
+          path: umskt.exe
 
 # 32-bit support will happen when everything's all good

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export PATH="/c/TDM-GCC-64/bin:$PATH"
-          export OPENSSL_PREFIX="$(cygpath -w "$GITHUB_WORKSPACE")\\openssl-install-64"
+          export OPENSSL_PREFIX="$(cygpath -m "$GITHUB_WORKSPACE")\\openssl-install-64"
           echo "OPENSSL_PREFIX is: $OPENSSL_PREFIX"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,6 +42,7 @@ jobs:
             make
             perl
             nasm
+            mingw-w64-x86_64-tree
 
       - name: Cache OpenSSL 64-bit build
         id: cache-openssl
@@ -80,7 +81,6 @@ jobs:
           make -j$(nproc)
           make install_sw
           
-          # list files in the directory recursively (this is in msys2)
           tree $OPENSSL_PREFIX
 
       - name: Checkout Source Tree

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,6 +71,7 @@ jobs:
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         shell: msys2 {0}
         run: |
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
           export OPENSSL_PREFIX="$(pwd)/openssl-install-64"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,8 +71,7 @@ jobs:
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         shell: msys2 {0}
         run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          export OPENSSL_PREFIX="${GITHUB_WORKSPACE}/openssl-install-64"
+          export OPENSSL_PREFIX="$(pwd)/openssl-install-64"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,7 +94,7 @@ jobs:
           $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
 
-          Get-ChildItem -Recurse $OPENSSL_ROOT
+          Get-ChildItem -Recurse D:\
 
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,12 +44,6 @@ jobs:
             nasm
             tree
 
-      - name: Download OpenSSL-TDM binaries
-        uses: actions/checkout@v4
-        with:
-          repository: UMSKT/winactiontest
-          path: OpenSSL-TDM
-
       - name: Setup TDM-GCC
         run: |
           Write-Host Downloading TDM-GCC v10.3.0...
@@ -69,16 +63,20 @@ jobs:
       - name: Checkout Source Tree
         uses: actions/checkout@v4
 
+      - name: Download OpenSSL-TDM-64 release asset
+        shell: pwsh
+        run: |
+          $url = "https://github.com/UMSKT/winactiontest/releases/download/openssl/OpenSSL-TDM-64.zip"
+          Invoke-WebRequest -Uri $url -OutFile "OpenSSL-TDM-64.zip"
+          Expand-Archive -Path "OpenSSL-TDM-64.zip" -DestinationPath "$env:GITHUB_WORKSPACE"
+
       - name: Configure UMSKT (TDM-GCC 64-bit)
         shell: pwsh
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
-          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/OpenSSL-TDM"
+          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-64"
           $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
-
-          Get-ChildItem -Recurse D:\
-
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `
             -DCMAKE_CXX_COMPILER="g++" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,6 +79,9 @@ jobs:
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
           make -j$(nproc)
           make install_sw
+          
+          # list files in the directory recursively (this is in msys2)
+          tree $OPENSSL_PREFIX
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,8 +41,6 @@ jobs:
             git
             make
             perl
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-pkg-config
             nasm
 
       - name: Cache OpenSSL 64-bit build
@@ -52,10 +50,28 @@ jobs:
           path: ${{ env.OPENSSL_PREFIX }}
           key: openssl-${{ env.OPENSSL_VERSION }}-msys2-mingw64
 
+      - name: Setup TDM-GCC
+        run: |
+          Write-Host Downloading TDM-GCC v10.3.0...
+          Invoke-WebRequest -Uri 'https://github.com/jmeubank/tdm-gcc/releases/download/v10.3.0-tdm64-2/tdm64-gcc-10.3.0-2.exe' -OutFile 'C:\Windows\temp\TDM-GCC-64.exe'
+          Write-Host Creating directory...
+          New-Item -ItemType Directory -Path 'C:\TDM-GCC-64'
+          Write-Host Copying files [Set 1/3]...
+          Start-Process '7z' -ArgumentList 'e C:\Windows\temp\TDM-GCC-64.exe -oC:\TDM-GCC-64 -y' -Wait
+          Write-Host Copying files [Set 2/3]...
+          Start-Process '7z' -ArgumentList 'e C:\TDM-GCC-64\*.tar.xz -oC:\TDM-GCC-64 -y' -Wait
+          Write-Host Copying files [Set 3/3]...
+          Start-Process '7z' -ArgumentList 'x C:\TDM-GCC-64\*.tar -oC:\TDM-GCC-64 -y' -Wait
+          Write-Host Adding environment variables...
+          $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
+          [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+          
       - name: Build OpenSSL 64-bit (if not cached)
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         shell: msys2 {0}
         run: |
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
@@ -68,6 +84,7 @@ jobs:
       - name: Configure UMSKT (TDM-GCC 64-bit)
         shell: msys2 {0}
         run: |
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
           cmake -G "MinGW Makefiles" \
             -DCMAKE_C_COMPILER="mingw-w64-x86_64-gcc" \
             -DCMAKE_CXX_COMPILER="mingw-w64-x86_64-g++" \
@@ -89,72 +106,4 @@ jobs:
           name: UMSKT-TDM64
           path: ./Release/*
 
-  build-tdm32:
-    runs-on: windows-latest
-    env:
-      OPENSSL_VERSION: "3.1.8"
-      OPENSSL_PREFIX: "${{ github.workspace }}/openssl-install-32"
-    steps:
-      - name: Install MSYS2 and dependencies
-        uses: msys2/setup-msys2@v2
-        with:
-          update: true
-          install: >-
-            git
-            make
-            perl
-            mingw-w64-i686-gcc
-            nasm
-
-      - name: Download and Install TDM-GCC-64
-        run: |
-          Invoke-WebRequest -Uri "https://jmeubank.github.io/tdm-gcc/download/tdm64-gcc-10.3.0.exe" -OutFile "$env:TEMP\tdm64-gcc.exe"
-          Start-Process -FilePath "$env:TEMP\tdm64-gcc.exe" -ArgumentList "/VERYSILENT", "/DIR=C:\TDM-GCC-64" -Wait
-
-      - name: Cache OpenSSL 32-bit build
-        id: cache-openssl
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.OPENSSL_PREFIX }}
-          key: openssl-${{ env.OPENSSL_VERSION }}-msys2-tdmgcc32
-
-      - name: Build OpenSSL 32-bit (if not cached)
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        shell: msys2 {0}
-        run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
-          cd openssl
-          ./Configure mingw no-shared --prefix="${OPENSSL_PREFIX}" CFLAGS="-m32" CXXFLAGS="-m32"
-          make -j$(nproc)
-          make install
-
-      - name: Checkout Source Tree
-        uses: actions/checkout@v4
-
-      - name: Configure UMSKT (TDM-GCC 32-bit)
-        shell: msys2 {0}
-        run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          cmake -G "MinGW Makefiles" \
-            -DCMAKE_C_COMPILER="gcc" \
-            -DCMAKE_CXX_COMPILER="g++" \
-            -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}" \
-            -DOPENSSL_INCLUDE_DIR="${OPENSSL_PREFIX}/include" \
-            -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_PREFIX}/lib/libcrypto.a" \
-            -DOPENSSL_SSL_LIBRARY="${OPENSSL_PREFIX}/lib/libssl.a" \
-            -DCMAKE_C_FLAGS="-m32" \
-            -DCMAKE_CXX_FLAGS="-m32" \
-            .
-
-      - name: Build UMSKT (TDM-GCC 32-bit)
-        shell: msys2 {0}
-        run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          make
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: UMSKT-TDM32
-          path: ./Release/*
+# 32-bit support will happen when everything's all good

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,12 +44,11 @@ jobs:
             nasm
             tree
 
-      - name: Cache OpenSSL 64-bit build
-        id: cache-openssl
-        uses: actions/cache@v4
+      - name: Download OpenSSL-TDM binaries
+        uses: actions/checkout@v4
         with:
-          path: ${{ env.OPENSSL_PREFIX }}
-          key: openssl-${{ env.OPENSSL_VERSION }}-msys2-mingw64
+          repository: UMSKT/winactiontest
+          path: OpenSSL-TDM
 
       - name: Setup TDM-GCC
         run: |
@@ -67,22 +66,6 @@ jobs:
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
           [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-          
-      - name: Build OpenSSL 64-bit (if not cached)
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        shell: msys2 {0}
-        run: |
-          export PATH="/c/TDM-GCC-64/bin:$PATH"
-          export OPENSSL_PREFIX="$(cygpath -m "$GITHUB_WORKSPACE")\\openssl-install-64"
-          echo "OPENSSL_PREFIX is: $OPENSSL_PREFIX"
-          git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
-          cd openssl
-          ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
-          make -j$(nproc)
-          make install_sw
-          
-          tree $OPENSSL_PREFIX
-
       - name: Checkout Source Tree
         uses: actions/checkout@v4
 
@@ -90,7 +73,7 @@ jobs:
         shell: pwsh
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
-          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
+          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/OpenSSL-TDM"
           $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,6 +94,8 @@ jobs:
           $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
 
+          Get-ChildItem -Recurse $OPENSSL_ROOT
+
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `
             -DCMAKE_CXX_COMPILER="g++" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,11 +73,15 @@ jobs:
         run: |
           export PATH="/c/TDM-GCC-64/bin:$PATH"
           export OPENSSL_PREFIX="$(pwd)/openssl-install-64"
+          echo "OPENSSL_PREFIX is: $OPENSSL_PREFIX"
           git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
           cd openssl
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
           make -j$(nproc)
           make install_sw
+          ls -l "$OPENSSL_PREFIX"
+          ls -l "$OPENSSL_PREFIX/lib"
+          ls -l "$OPENSSL_PREFIX/include"
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4
@@ -89,7 +93,7 @@ jobs:
           $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
           $OPENSSL_LIB = "$OPENSSL_ROOT"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
-          tree /f D:\
+          Get-ChildItem -Recurse $env:GITHUB_WORKSPACE\openssl-install-64
           throw "Testing"
 
           cmake -G "MinGW Makefiles" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,7 +77,7 @@ jobs:
           cd openssl
           ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
           make -j$(nproc)
-          make install
+          make install_sw
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4
@@ -86,13 +86,17 @@ jobs:
         shell: pwsh
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
+          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
+          $OPENSSL_LIB = "$OPENSSL_ROOT"
+          $OPENSSL_INC = "$OPENSSL_ROOT/include"
+
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `
             -DCMAKE_CXX_COMPILER="g++" `
-            -DOPENSSL_ROOT_DIR="${env:GITHUB_WORKSPACE}/openssl-install-64" `
-            -DOPENSSL_INCLUDE_DIR="${env:GITHUB_WORKSPACE}/openssl-install-64/include" `
-            -DOPENSSL_CRYPTO_LIBRARY="${env:GITHUB_WORKSPACE}/openssl-install-64/lib/libcrypto.a" `
-            -DOPENSSL_SSL_LIBRARY="${env:GITHUB_WORKSPACE}/openssl-install-64/lib/libssl.a" `
+            -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT" `
+            -DOPENSSL_INCLUDE_DIR="$OPENSSL_INC" `
+            -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_LIB/libcrypto.a" `
+            -DOPENSSL_SSL_LIBRARY="$OPENSSL_LIB/libssl.a" `
             -DCMAKE_C_FLAGS="-m64" `
             -DCMAKE_CXX_FLAGS="-m64" `
             .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,20 +29,7 @@ on:
 jobs:
   build-tdm64:
     runs-on: windows-latest
-    env:
-      OPENSSL_VERSION: "3.1.8"
-      OPENSSL_PREFIX: "${{ github.workspace }}/openssl-install-64"
     steps:
-      - name: Install MSYS2 and dependencies
-        uses: msys2/setup-msys2@v2
-        with:
-          update: true
-          install: >-
-            git
-            make
-            perl
-            nasm
-            tree
 
       - name: Setup TDM-GCC
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,6 +89,8 @@ jobs:
           $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
           $OPENSSL_LIB = "$OPENSSL_ROOT"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
+          tree /f $OPENSSL_ROOT
+          throw "Testing"
 
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,10 +27,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-tdm64:
+  build-tdm:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, x86]
     steps:
-
       - name: Setup TDM-GCC
         run: |
           Write-Host Downloading TDM-GCC v10.3.0...
@@ -50,19 +52,34 @@ jobs:
       - name: Checkout Source Tree
         uses: actions/checkout@v4
 
-      - name: Download OpenSSL-TDM-64 release asset
+      - name: Download OpenSSL-TDM release asset
         shell: pwsh
         run: |
-          $url = "https://github.com/UMSKT/winactiontest/releases/download/openssl/OpenSSL-TDM-64.zip"
-          Invoke-WebRequest -Uri $url -OutFile "OpenSSL-TDM-64.zip"
-          Expand-Archive -Path "OpenSSL-TDM-64.zip" -DestinationPath "$env:GITHUB_WORKSPACE"
+          if ('${{ matrix.arch }}' -eq 'x64') {
+            $url = "https://github.com/UMSKT/winactiontest/releases/download/openssl/OpenSSL-TDM-64.zip"
+            $dest = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-64"
+            $libdir = "lib64"
+            $cmake_flags = "-m64"
+            $openssl_root = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-64"
+          } else {
+            $url = "https://github.com/UMSKT/winactiontest/releases/download/openssl/OpenSSL-TDM-32.zip"
+            $dest = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-32"
+            $libdir = "lib32"
+            $cmake_flags = "-m32"
+            $openssl_root = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-32"
+          }
+          Invoke-WebRequest -Uri $url -OutFile "OpenSSL-TDM.zip"
+          Expand-Archive -Path "OpenSSL-TDM.zip" -DestinationPath $env:GITHUB_WORKSPACE
+          echo "OPENSSL_ROOT=$openssl_root" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "OPENSSL_LIBDIR=$libdir" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CMAKE_FLAGS=$cmake_flags" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Configure UMSKT (TDM-GCC 64-bit)
+      - name: Configure UMSKT (TDM-GCC ${{ matrix.arch }})
         shell: pwsh
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
-          $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/OpenSSL-TDM-64"
-          $OPENSSL_LIB = "$OPENSSL_ROOT/lib64"
+          $OPENSSL_ROOT = "$env:OPENSSL_ROOT"
+          $OPENSSL_LIB = "$OPENSSL_ROOT/$env:OPENSSL_LIBDIR"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
           cmake -G "MinGW Makefiles" `
             -DCMAKE_C_COMPILER="gcc" `
@@ -71,11 +88,11 @@ jobs:
             -DOPENSSL_INCLUDE_DIR="$OPENSSL_INC" `
             -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_LIB/libcrypto.a" `
             -DOPENSSL_SSL_LIBRARY="$OPENSSL_LIB/libssl.a" `
-            -DCMAKE_C_FLAGS="-m64" `
-            -DCMAKE_CXX_FLAGS="-m64" `
+            -DCMAKE_C_FLAGS="$env:CMAKE_FLAGS" `
+            -DCMAKE_CXX_FLAGS="$env:CMAKE_FLAGS" `
             .
 
-      - name: Build UMSKT (TDM-GCC 64-bit)
+      - name: Build UMSKT (TDM-GCC ${{ matrix.arch }})
         shell: pwsh
         run: |
           $env:PATH = 'C:\TDM-GCC-64\bin;' + $env:PATH
@@ -84,7 +101,5 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: UMSKT-TDM64
+          name: UMSKT-TDM${{ matrix.arch }}
           path: umskt.exe
-
-# 32-bit support will happen when everything's all good

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,176 +23,138 @@ name: C/C++ CI (Windows)
 on:
   push:
     branches: [ "*" ]
-    paths-ignore: [ '**.md', 'doc/**', '.idea/**'] # If only these files are edited, skip
+    paths-ignore: [ '**.md', 'doc/**', '.idea/**']
   workflow_dispatch:
 
 jobs:
-  build-32bit:
+  build-tdm64:
     runs-on: windows-latest
+    env:
+      OPENSSL_VERSION: "3.1.8"
+      OPENSSL_PREFIX: "${{ github.workspace }}/openssl-install-64"
     steps:
-      # https://github.com/actions/runner-images/issues/6067#issuecomment-1213069040
-      - name: Install Windows XP Support for Visual Studio
+      - name: Install MSYS2 and dependencies
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            git
+            make
+            perl
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkg-config
+            nasm
+
+      - name: Cache OpenSSL 64-bit build
+        id: cache-openssl
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.OPENSSL_PREFIX }}
+          key: openssl-${{ env.OPENSSL_VERSION }}-msys2-mingw64
+
+      - name: Build OpenSSL 64-bit (if not cached)
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        shell: msys2 {0}
         run: |
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $componentsToAdd = @(
-            "Microsoft.VisualStudio.Component.WinXP"
-          )
-          [string]$workloadArgs = $componentsToAdd | ForEach-Object {" --add " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          if ($process.ExitCode -eq 0)
-          {
-              Write-Host "components have been successfully added"
-              Get-ChildItem C:\ProgramData\Microsoft\VisualStudio\Packages\Microsoft.Windows.XPSupport.*
-          }
-          else
-          {
-              Write-Host "components were not installed"
-              exit 1
-          }
-
-      - name: Download And Install 32-bit OpenSSL
-        run: |
-          $installDir = "$Env:ProgramFiles\OpenSSL"
-          # Define the URL for the JSON file containing the hashes
-          $jsonUrl = "https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json"
-          
-          # Download the JSON data
-          $jsonData = Invoke-RestMethod -Uri $jsonUrl
-          
-          # Initialize variables for the latest version and URL
-          $latestVersion = "0.0.0"
-          $latestUrl = ""
-            
-          # Iterate through the files to find the latest 3.1.x version
-          foreach ($file in $jsonData.files.PSObject.Properties) {
-              $details = $file.Value
-              if ($details.basever -like "3.1*" -and $file.Name -like "Win32OpenSSL*") {
-                    if ([version]$details.basever -gt [version]$latestVersion) {
-                      $latestVersion = $details.basever
-                      $latestUrl = $details.url
-                   }
-              }
-          }
-
-          # Output the latest version and URL
-          Write-Output "Latest OpenSSL Win32 3.1.x version: $latestVersion"
-          Write-Output "Download link: $latestUrl"
-
-          $installerURL = $latestURL
-          $installerName = "Win32OpenSSL.exe"
-          $installerPath = Join-Path -Path "${env:Temp}" -ChildPath "$installerName"
-
-          (New-Object System.Net.WebClient).DownloadFile($installerURL, $installerPath)
-          
-          Remove-Item "$installDir" -Force -Recurse
-          $installerArgs = '/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`""
-          Start-Process -FilePath $installerPath -ArgumentList $installerArgs -Wait -PassThru
+          git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
+          cd openssl
+          ./Configure mingw64 no-shared --prefix="${OPENSSL_PREFIX}"
+          make -j$(nproc)
+          make install
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+      - name: Configure UMSKT (TDM-GCC 64-bit)
+        shell: msys2 {0}
+        run: |
+          cmake -G "MinGW Makefiles" \
+            -DCMAKE_C_COMPILER="mingw-w64-x86_64-gcc" \
+            -DCMAKE_CXX_COMPILER="mingw-w64-x86_64-g++" \
+            -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}" \
+            -DOPENSSL_INCLUDE_DIR="${OPENSSL_PREFIX}/include" \
+            -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_PREFIX}/lib/libcrypto.a" \
+            -DOPENSSL_SSL_LIBRARY="${OPENSSL_PREFIX}/lib/libssl.a" \
+            -DCMAKE_C_FLAGS="-m64" \
+            -DCMAKE_CXX_FLAGS="-m64" \
+            .
 
-      - name: Configure UMSKT
-        uses: threeal/cmake-action@v1.2.0
-        with:
-          generator: "Visual Studio 17 2022"
-          options: CMAKE_SYSTEM_VERSION="5.1.2600"
-          args: -A "Win32" -T v141_xp
-
-      - name: Build UMSKT
-        working-directory: build
-        run: msbuild ALL_BUILD.vcxproj /P:Configuration=Release
+      - name: Build UMSKT (TDM-GCC 64-bit)
+        shell: msys2 {0}
+        run: make
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: UMSKT-Win32
-          path: build/Release
+          name: UMSKT-TDM64
+          path: ./Release/*
 
-  build-64bit:
+  build-tdm32:
     runs-on: windows-latest
+    env:
+      OPENSSL_VERSION: "3.1.8"
+      OPENSSL_PREFIX: "${{ github.workspace }}/openssl-install-32"
     steps:
-      - name: Install Windows XP Support for Visual Studio
+      - name: Install MSYS2 and dependencies
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            git
+            make
+            perl
+            mingw-w64-i686-gcc
+            nasm
+
+      - name: Download and Install TDM-GCC-64
         run: |
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $componentsToAdd = @(
-            "Microsoft.VisualStudio.Component.WinXP"
-          )
-          [string]$workloadArgs = $componentsToAdd | ForEach-Object {" --add " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          if ($process.ExitCode -eq 0)
-          {
-              Write-Host "components have been successfully added"
-              Get-ChildItem C:\ProgramData\Microsoft\VisualStudio\Packages\Microsoft.Windows.XPSupport.*
-          }
-          else
-          {
-              Write-Host "components were not installed"
-              exit 1
-          }
-    
-      - name: Download And Install 64-bit OpenSSL
+          Invoke-WebRequest -Uri "https://jmeubank.github.io/tdm-gcc/download/tdm64-gcc-10.3.0.exe" -OutFile "$env:TEMP\tdm64-gcc.exe"
+          Start-Process -FilePath "$env:TEMP\tdm64-gcc.exe" -ArgumentList "/VERYSILENT", "/DIR=C:\TDM-GCC-64" -Wait
+
+      - name: Cache OpenSSL 32-bit build
+        id: cache-openssl
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.OPENSSL_PREFIX }}
+          key: openssl-${{ env.OPENSSL_VERSION }}-msys2-tdmgcc32
+
+      - name: Build OpenSSL 32-bit (if not cached)
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        shell: msys2 {0}
         run: |
-          $installDir = "$Env:ProgramFiles\OpenSSL"
-          # Define the URL for the JSON file containing the hashes
-          $jsonUrl = "https://raw.githubusercontent.com/slproweb/opensslhashes/master/win32_openssl_hashes.json"
-          
-          # Download the JSON data
-          $jsonData = Invoke-RestMethod -Uri $jsonUrl
-          
-          # Initialize variables for the latest version and URL
-          $latestVersion = "0.0.0"
-          $latestUrl = ""
-            
-          # Iterate through the files to find the latest 3.1.x version
-          foreach ($file in $jsonData.files.PSObject.Properties) {
-              $details = $file.Value
-              if ($details.basever -like "3.1*" -and $file.Name -like "Win64OpenSSL*") {
-                    if ([version]$details.basever -gt [version]$latestVersion) {
-                      $latestVersion = $details.basever
-                      $latestUrl = $details.url
-                   }
-              }
-          }
-
-          # Output the latest version and URL
-          Write-Output "Latest OpenSSL Win64 3.1.x version: $latestVersion"
-          Write-Output "Download link: $latestUrl"
-
-          $installerURL = $latestURL
-          $installerName = "Win64OpenSSL.exe"
-          $installerPath = Join-Path -Path "${env:Temp}" -ChildPath "$installerName"
-
-          (New-Object System.Net.WebClient).DownloadFile($installerURL, $installerPath)
-          
-          Remove-Item "$installDir" -Force -Recurse
-          $installerArgs = '/silent', '/sp-', '/suppressmsgboxes', "/DIR=`"$installDir`""
-          Start-Process -FilePath $installerPath -ArgumentList $installerArgs -Wait -PassThru
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
+          git clone --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl.git
+          cd openssl
+          ./Configure mingw no-shared --prefix="${OPENSSL_PREFIX}" CFLAGS="-m32" CXXFLAGS="-m32"
+          make -j$(nproc)
+          make install
 
       - name: Checkout Source Tree
         uses: actions/checkout@v4
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1
+      - name: Configure UMSKT (TDM-GCC 32-bit)
+        shell: msys2 {0}
+        run: |
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
+          cmake -G "MinGW Makefiles" \
+            -DCMAKE_C_COMPILER="gcc" \
+            -DCMAKE_CXX_COMPILER="g++" \
+            -DOPENSSL_ROOT_DIR="${OPENSSL_PREFIX}" \
+            -DOPENSSL_INCLUDE_DIR="${OPENSSL_PREFIX}/include" \
+            -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_PREFIX}/lib/libcrypto.a" \
+            -DOPENSSL_SSL_LIBRARY="${OPENSSL_PREFIX}/lib/libssl.a" \
+            -DCMAKE_C_FLAGS="-m32" \
+            -DCMAKE_CXX_FLAGS="-m32" \
+            .
 
-      - name: Configure UMSKT
-        uses: threeal/cmake-action@v1.2.0
-        with:
-          generator: "Visual Studio 17 2022"
-          args: -A "x64" -T "v141_xp"
-
-      - name: Build UMSKT
-        working-directory: build
-        run: msbuild ALL_BUILD.vcxproj /P:Configuration=Release
+      - name: Build UMSKT (TDM-GCC 32-bit)
+        shell: msys2 {0}
+        run: |
+          export PATH="/c/TDM-GCC-64/bin:$PATH"
+          make
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: UMSKT-Win64
-          path: build/Release
+          name: UMSKT-TDM32
+          path: ./Release/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
           $OPENSSL_ROOT = "$env:GITHUB_WORKSPACE/openssl-install-64"
           $OPENSSL_LIB = "$OPENSSL_ROOT"
           $OPENSSL_INC = "$OPENSSL_ROOT/include"
-          tree /f $OPENSSL_ROOT
+          tree /f D:\
           throw "Testing"
 
           cmake -G "MinGW Makefiles" `

--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,9 @@ CMakeSettings.json
 
 # Visual Studio
 .vs/
+
+CPM_modules
+CPM_*.cmake
+cpm-package-lock.cmake
+*.a
+*_cmrc*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.12)
 PROJECT(UMSKT)
 
+# Force TDM-GCC on Windows if not using MSVC
+if (WIN32 AND NOT MSVC)
+    set(CMAKE_C_COMPILER "C:/TDM-GCC-64/bin/gcc.exe" CACHE FILEPATH "C Compiler" FORCE)
+    set(CMAKE_CXX_COMPILER "C:/TDM-GCC-64/bin/g++.exe" CACHE FILEPATH "C++ Compiler" FORCE)
+    message(STATUS "[UMSKT] Forcing use of TDM-GCC in C:/TDM-GCC-64")
+endif()
+
 SET(CMAKE_CXX_STANDARD 17)
 SET(CMAKE_OSX_SYSROOT "macosx" CACHE PATH "macOS SDK path")
 
@@ -207,6 +214,12 @@ ELSE()
     TARGET_INCLUDE_DIRECTORIES(umskt PUBLIC ${OPENSSL_INCLUDE_DIR})
     TARGET_LINK_LIBRARIES(umskt _umskt ${OPENSSL_CRYPTO_LIBRARIES} ${ZLIB_LIBRARIES} fmt nlohmann_json::nlohmann_json umskt::rc ${UMSKT_LINK_LIBS})
     TARGET_LINK_DIRECTORIES(umskt PUBLIC ${UMSKT_LINK_DIRS})
+
+    # Link required Windows system libraries for OpenSSL
+    if (WIN32)
+        target_link_libraries(umskt crypt32 ws2_32)
+    endif()
+
     IF(MSVC AND MSVC_MSDOS_STUB)
         SET_PROPERTY(TARGET umskt APPEND PROPERTY LINK_FLAGS /STUB:${MSVC_MSDOS_STUB})
     ENDIF()


### PR DESCRIPTION
This removes all ties from Microsoft's toolset, so we don't have to worry about them removing v141_xp support.

This uses prebuilt blobs for OpenSSL, which can be found at https://github.com/UMSKT/winactiontest/releases/tag/openssl. Didn't want to do that, but it turns out msys2 on GitHub Actions just doesn't work.