### PR TITLE
Native arm64 compilation for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,13 +28,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - arch: x86
+            runner: ubuntu-latest
           - arch: x86_64
+            runner: ubuntu-latest
           - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{matrix.runner}}
     steps:
     - name: Checkout Source Tree
       uses: actions/checkout@v4


### PR DESCRIPTION
Avoids arm64 compilation on Linux taking the time it takes for two suns to die out by compiling arm64 on an arm64 runner.