### PR TITLE
Pipe support for confirmation ID's

### DIFF
--- a/src/cli.h
+++ b/src/cli.h
@@ -96,6 +96,7 @@ public:
     static void printID(DWORD *pid);
     void printKey(char *pk);
     static bool stripKey(const char *in_key, char out_key[PK_LENGTH]);
+    static std::string readFromStdin();
 
     int BINK1998Generate();
     int BINK2002Generate();


### PR DESCRIPTION
An update alongside xpmgr that allows doing cmd one-liners like this:
`umskt -b 2A -c 35 | xpmgr_x86 /ipk && xpmgr_x86 /dti | umskt -i | xpmgr_x86 /atp`