### PR TITLE
Enable building on riscv64

### DIFF
--- a/src/libumskt/confid/confid.cpp
+++ b/src/libumskt/confid/confid.cpp
@@ -68,7 +68,7 @@ QWORD ConfirmationID::residue_sub(QWORD x, QWORD y)
 	return z;
 }
 
-#if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || (defined(__arm64__) && defined(__APPLE__))
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__aarch64__) || (defined(__arm64__) && defined(__APPLE__)) || (defined(__riscv) && (__SIZEOF_POINTER__ == 8))
 #ifdef __GNUC__
 inline QWORD ConfirmationID::__umul128(QWORD a, QWORD b, QWORD* hi)
 {


### PR DESCRIPTION
Turns out that treating riscv64 like the other 64-bit platforms in `confid.cpp` is all it takes to get this project working on riscv64. I tested this on Debian sid on both riscv64 and amd64 (the latter to make sure I didn't break anything) and was able to activate all of the products I tried (Windows XP, Office XP, and Plus DME) without any issues.

I did not edit the readme file as I'm assuming there are no plans to officially support riscv64. If you want that edited too, just let me know and I can revise this PR.